### PR TITLE
mark multiple options as required vs other options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export type Command = {
    *   require: [['a', 'b'], 'c']
    * }
    */
-  require?: (string | string[])[];
+  require?: (string | string[] | (string | string[])[])[];
   /** Examples showcasing common usage of the command */
   examples?: (string | Example)[];
   /** What group to render the command in a MultiCommand */
@@ -357,7 +357,12 @@ const parseCommand = (
       .filter(
         option =>
           (typeof option === 'string' && !(option in rest._all)) ||
-          (typeof option === 'object' && !option.find(o => o in rest._all)) ||
+          (typeof option === 'object' &&
+            !option.find(
+              o =>
+                (typeof o === 'string' && o in rest._all) ||
+                (typeof o === 'object' && !o.find(op => op in rest._all))
+            )) ||
           // tslint:disable-next-line strict-type-predicates
           (typeof option === 'string' && rest._all[option] === null)
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,6 +352,11 @@ const parseCommand = (
     return;
   }
 
+  const formatArrayOption = (option: any): string =>
+    typeof option === 'string'
+      ? `--${option}`
+      : option.map(formatArrayOption).join(', ');
+
   if (command.require) {
     const missing = command.require
       .filter(
@@ -369,7 +374,7 @@ const parseCommand = (
       .map(option =>
         typeof option === 'string'
           ? `--${option}`
-          : `(--${option.join(' or --')})`
+          : `(${(option as any[]).map(formatArrayOption).join(' or ')})`
       );
 
     if (missing.length > 0) {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -329,7 +329,7 @@ Examples
 
 exports[`single command app errors without multiple required flags - or 2`] = `
 Array [
-  "Missing required arg: (--a or --b,c)",
+  "Missing required arg: (--a or --b, --c)",
 ]
 `;
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -307,6 +307,32 @@ Array [
 ]
 `;
 
+exports[`single command app errors without multple required flags - or 1`] = `
+Array [
+  "
+echo
+
+  Print a string to the terminal 
+
+Options
+
+  --b string                            
+  -h, --help    Display the help output 
+
+Examples
+
+  echo foo               
+  echo \\"Intense message\\" 
+",
+]
+`;
+
+exports[`single command app errors without multple required flags - or 2`] = `
+Array [
+  "Missing required arg: (--a or --b,c)",
+]
+`;
+
 exports[`single command app errors without required flag - or 1`] = `
 Array [
   "
@@ -358,6 +384,10 @@ Array [
   "Missing required arg: --value",
 ]
 `;
+
+exports[`single command app errors without required flags - or 1`] = `undefined`;
+
+exports[`single command app errors without required flags - or 2`] = `undefined`;
 
 exports[`single command app help 1`] = `
 Array [

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -307,7 +307,7 @@ Array [
 ]
 `;
 
-exports[`single command app errors without multple required flags - or 1`] = `
+exports[`single command app errors without multiple required flags - or 1`] = `
 Array [
   "
 echo
@@ -327,7 +327,7 @@ Examples
 ]
 `;
 
-exports[`single command app errors without multple required flags - or 2`] = `
+exports[`single command app errors without multiple required flags - or 2`] = `
 Array [
   "Missing required arg: (--a or --b,c)",
 ]
@@ -384,10 +384,6 @@ Array [
   "Missing required arg: --value",
 ]
 `;
-
-exports[`single command app errors without required flags - or 1`] = `undefined`;
-
-exports[`single command app errors without required flags - or 2`] = `undefined`;
 
 exports[`single command app help 1`] = `
 Array [

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -128,7 +128,7 @@ describe('single command app', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  test('errors without multple required flags - or', () => {
+  test('errors without multiple required flags - or', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     // @ts-ignore
     jest.spyOn(process, 'exit').mockImplementationOnce(() => {});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -127,6 +127,28 @@ describe('single command app', () => {
     // @ts-ignore
     expect(process.exit).toHaveBeenCalledWith(1);
   });
+
+  test('errors without multple required flags - or', () => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    // @ts-ignore
+    jest.spyOn(process, 'exit').mockImplementationOnce(() => {});
+
+    app(
+      {
+        ...echo,
+        options: [{ name: 'b', description: '' }],
+        require: [['a', ['b', 'c']]]
+      },
+      { argv: ['--b', 'b'] }
+    );
+
+    // @ts-ignore
+    expect(console.log.mock.calls[0]).toMatchSnapshot();
+    // @ts-ignore
+    expect(console.log.mock.calls[1]).toMatchSnapshot();
+    // @ts-ignore
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 test('renders logos', () => {
@@ -193,7 +215,7 @@ test('should display code', () => {
               ]
             }
           }
-        }      
+        }
        \`\`\``
       }
     ]


### PR DESCRIPTION
Makes it possible to require different sets of options such as:

```sh
command --a
# or
command --b --c
```